### PR TITLE
Fix bugs: division operator, typos, missing imports, deprecation warnings

### DIFF
--- a/snow/crystals.py
+++ b/snow/crystals.py
@@ -4,27 +4,34 @@
 
 Module to work with bulk crystals instead of waveguides
 """
+import time
+import numpy as np
+from numpy.fft import fftshift
+from scipy.constants import pi, c
+
+from . import nlo
+from . import pulses
 
 class nonlinear_crystal():
-    
+
     def __init__(self, L, n_func, chi2, alpha=0):
         self.L = L
         self.n_func = n_func
         self.chi2 = chi2
-        self.alpha = alpha      
-  
-    def propagate_NEE_fd(self, pulse, h, v_ref=None,
-                         verbose=True, zcheck_step = 0.5e-3, z0=0):
-        
+        self.alpha = alpha
+
+    def propagate_NEE_fd(self, pulse, v_ref=None,
+                         verbose=True, z0=0):
+
         #Timer
         tic_total = time.time()
-         
-        #Get stuff 
+
+        #Get stuff
         wl = pulse.wl
         f0 = pulse.f0
         f_abs = pulse.f_abs
         Omega  = pulse.Omega
-        
+
         n = self.n_func(wl)
         beta = 2*pi*f_abs*n/c
 
@@ -33,7 +40,7 @@ class nonlinear_crystal():
             beta_1 = fftshift(np.gradient(fftshift(beta), 2*pi*df))
             vg = 1/beta_1
             v_ref = vg[0]
-        
+
         beta_ref = beta[0]
         beta_1_ref = 1/v_ref
         D = beta - beta_ref - Omega/v_ref - 1j*self.alpha/2
@@ -41,26 +48,24 @@ class nonlinear_crystal():
         chi2 = self.chi2
         omega_ref = 2*pi*f0
         omega_abs = omega_ref + Omega
-             
-        def k(z):  
+
+        def k(z):
             return chi2(z)*omega_abs/(4*n*c)
 
-        [a, a_evol] = NEE(t = pulse.t, 
+        [a, a_evol] = nlo.NEE(t = pulse.t,
                           x = pulse.a,
                           Omega = Omega,
                           f0 = pulse.f0,
                           L = self.L,
-                          D = D, 
-                          b0 = beta_ref, 
-                          b1_ref = beta_1_ref, 
-                          k = k, 
-                          h = h, 
-                          zcheck_step = zcheck_step, 
-                          z0 = 0,
+                          D = D,
+                          b0 = beta_ref,
+                          b1_ref = beta_1_ref,
+                          k = k,
+                          z0 = z0,
                           verbose = verbose)
-        
+
         tdelta = time.time() - tic_total
         print('Total time = %0.1f s' %(tdelta))
-        
-        output_pulse = pulses.pulse(pulse.t, a, pulse.wl0)
+
+        output_pulse = pulses.pulse(pulse.t, a, pulse.wl0, pulse.frep)
         return output_pulse, a_evol

--- a/snow/opos.py
+++ b/snow/opos.py
@@ -193,9 +193,9 @@ class opo:
                 if self.pulsetype == 'sech':
                     pulse = pulses.sech_pulse(self.t, FWHM=tau, Ppeak=Ppeak,
                                               f_ref=f_ref, f0=f0_sh, Npwr_dB=Noise_dB) #Sech pump pulse
-                elif self.pulsetype == 'guass':
-                    pulse = pulses.gassian_pulse(self.t, FWHM=tau, Ppeak=Ppeak,
-                                                 f_ref=f_ref, f0=f0_sh, Npwr_dB=Noise_dB) #Gaussian pump pulse
+                elif self.pulsetype == 'gauss':
+                    pulse = pulses.gaussian_pulse(self.t, FWHM=tau, Ppeak=Ppeak,
+                                                  f_ref=f_ref, f0=f0_sh, Npwr_dB=Noise_dB) #Gaussian pump pulse
                 in_pulse = pulse # input pulse for the first roundtrip
                 for ii in range(self.roundtrips):
                     [out_pulse, pulse_evol] = self.crystal.propagate_NEE_fd(in_pulse, self.h,
@@ -210,8 +210,8 @@ class opo:
                         pulse = pulses.sech_pulse(self.t, FWHM=tau, Ppeak=Ppeak,
                                                   f_ref=f_ref, f0=f0_sh, Npwr_dB=Noise_dB) #Sech pump pulse
                     elif self.pulsetype == 'gauss':
-                        pulse = pulses.gassian_pulse(self.t, FWHM=tau, Ppeak=Ppeak,
-                                                     f_ref=_ref, f0=f0_sh, Npwr_dB=Noise_dB) #Gaussian pump pulse
+                        pulse = pulses.gaussian_pulse(self.t, FWHM=tau, Ppeak=Ppeak,
+                                                      f_ref=f_ref, f0=f0_sh, Npwr_dB=Noise_dB) #Gaussian pump pulse
                     in_pulse = pulse+recycled_pulse
     
     def plot_3d_spectrum(self, pin_val, ax=None):

--- a/snow/pulses.py
+++ b/snow/pulses.py
@@ -350,7 +350,7 @@ class pulse:
         
         #Reference frequency:
         self.wl0 = wavelength 
-        self.f0 = c//wavelength 
+        self.f0 = c/wavelength
         
         #Repetition rate
         self.frep = frep

--- a/snow/util.py
+++ b/snow/util.py
@@ -53,7 +53,8 @@ def derivative( f, x, n, h ):
     d = np.array( [[0] * (n + 1)] * (n + 1), float )
 
     for i in range( n + 1 ):
-        d[i,0] = 0.5 * ( f( x + h ) - f( x - h ) ) / h
+        val = 0.5 * ( f( x + h ) - f( x - h ) ) / h
+        d[i,0] = val.item() if hasattr(val, 'item') else val
 
         powerOf4 = 1  # values of 4^j
         for j in range( 1, i + 1 ):

--- a/snow/waveguides.py
+++ b/snow/waveguides.py
@@ -197,7 +197,8 @@ class waveguide:
         for kw in range(wl.size):
             dndl = util.derivative(neff_T, wl[kw], n, wl_step) #Still need to add temp here
             neff = neff_T(wl[kw])
-            b1[kw] = (neff - wl[kw] * dndl)/c
+            val = (neff - wl[kw] * dndl)/c
+            b1[kw] = val.item() if hasattr(val, 'item') else val
         return b1
     
     def beta2(self, wl):
@@ -332,10 +333,10 @@ def neff_symmetric_slab(n0, n1, d, wl, mode='TE even', order=0):
     #Solve for Normalized variables: X=kx*d/2, Y=a*d/2
 
     #Initial condition
-    if mode=='TE even' or 'TM even':
+    if mode in ('TE even', 'TM even'):
         xmin = 0
         xmax = min(R, pi/2*(order+1))
-    elif mode=='TE odd' or 'TM odd':
+    elif mode in ('TE odd', 'TM odd'):
         xmin = pi/2
         xmax = min(R, pi*(order+1))
     else:


### PR DESCRIPTION
## Summary
- **pulses.py**: `c//wavelength` → `c/wavelength` — floor division instead of true division for center frequency. Practically harmless (sub-Hz error on ~10^14 Hz), but no reason to truncate here; almost certainly a typo.
- **waveguides.py**: fix always-true mode condition (`'TE even' or 'TM even'` evaluates the string as truthy — changed to `mode in ('TE even', 'TM even')`)
- **opos.py**: fix typos that would crash Gaussian pulse mode (`'guass'`→`'gauss'`, `gassian_pulse`→`gaussian_pulse`, `_ref`→`f_ref`)
- **crystals.py**: add missing imports (`time`, `numpy`, `nlo`, `pulses`), update `propagate_NEE_fd` call to current adaptive-RK45 `NEE` signature (removed `h` and `zcheck_step` params), pass `frep` to output pulse
- **util.py, waveguides.py**: fix NumPy ndim>0-to-scalar deprecation warnings (will become errors in future NumPy)

## Test plan
- [x] Existing `test_waveguides.py` passes with zero warnings (including with `-W error::DeprecationWarning`)
- [x] SHG simulation (tutorial 5 workflow) produces correct results and conserves energy

🤖 Generated with [Claude Code](https://claude.com/claude-code)